### PR TITLE
Add dependency verifier and color constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /*.local.php
+.idea

--- a/commands/CommitCommand.php
+++ b/commands/CommitCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 class CommitCommand
 {
     private $package;
@@ -42,7 +44,7 @@ class CommitCommand
 
     private function commit(string $package, string $targetPath): void
     {
-        stdoutln($package, 32);
+        stdoutln($package, Color::GREEN);
         $command = 'cd ' . escapeshellarg($targetPath) . ' && git add . && git commit -m ' . escapeshellarg($this->message);
         $output = trim(shell_exec($command));
 

--- a/commands/DependencyVerifyCommand.php
+++ b/commands/DependencyVerifyCommand.php
@@ -20,6 +20,9 @@ class DependencyVerifyCommand
 
         for ($i = 0; $i < self::THREADS_MAX; $i++) {
             $shouldWork = $this->fork();
+            if ($shouldWork) {
+                break;
+            }
         }
 
         if ($this->isParent) {

--- a/commands/DependencyVerifyCommand.php
+++ b/commands/DependencyVerifyCommand.php
@@ -13,7 +13,6 @@ class DependencyVerifyCommand
     public $lockFile = __DIR__ . '/../runtime/composer-verify.lock';
     private $errored = [];
     private $isParent = true;
-    private $forks = [];
 
     public function run(array $allowed = [])
     {
@@ -122,8 +121,6 @@ class DependencyVerifyCommand
                 // We are a fork, so we should make the main work
                 return true;
             }
-
-            $this->forks[$pid] = true;
 
             // We just created a fork, so we shouldn't do anything
             return false;

--- a/commands/DependencyVerifyCommand.php
+++ b/commands/DependencyVerifyCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace yiidev\commands;
+
+use Color;
+
+class DependencyVerifyCommand
+{
+    private const THREADS_MAX = 5;
+
+    public $packagesDir = __DIR__ . '/../dev';
+    public $logFile = __DIR__ . '/../runtime/composer-verify.log';
+    public $lockFile = __DIR__ . '/../runtime/composer-verify.lock';
+    private $errored = [];
+    private $isParent = true;
+
+    public function run()
+    {
+        $packages = require __DIR__ . '/../packages.php';
+
+        for ($i = 0; $i < self::THREADS_MAX; $i++) {
+            $shouldWork = $this->fork();
+        }
+
+        if ($this->isParent) {
+            $start = microtime(true);
+
+            if (file_exists($this->logFile)) {
+                unlink($this->logFile);
+            }
+            if (file_exists($this->lockFile)) {
+                unlink($this->lockFile);
+            }
+
+            touch($this->logFile);
+            touch($this->lockFile);
+        }
+
+        foreach ($packages as $package => $directory) {
+            if ($shouldWork) {
+                if ($this->canUse($package)) {
+                    $targetPath = $this->packagesDir . DIRECTORY_SEPARATOR . $directory;
+
+                    if (!is_dir($targetPath)) {
+                        stderrln("Package $package does not exist", Color::YELLOW);
+                    } elseif (file_exists($targetPath . DIRECTORY_SEPARATOR . 'composer.json')) {
+                        $this->composerUpdate($package, $targetPath);
+                    }
+                }
+            }
+        }
+
+        if ($this->isParent) {
+            $this->waitForks();
+
+            $time = round(microtime(true) - $start, 2);
+            stdoutln('');
+            stdoutln('');
+            stdoutln("Finished in $time sec. You can see the result in $this->logFile", Color::GREEN);
+        }
+    }
+
+    private function composerUpdate(string $package, string $targetPath)
+    {
+        $path = escapeshellarg($targetPath);
+        $command = "composer update --prefer-dist --no-progress --working-dir $path --no-ansi 2>&1";
+        $output = [];
+
+        exec($command, $output, $result);
+
+        if ($result === 0) {
+            stderrln("Package $package is ok", Color::GREEN);
+        } else {
+            $this->errored[] = $package;
+
+            $file = fopen($this->logFile, 'ab');
+            flock($file, LOCK_EX);
+            fwrite($file, implode(PHP_EOL, $output));
+            fwrite($file, PHP_EOL . str_repeat('-', 10) . PHP_EOL);
+            flock($file, LOCK_UN);
+
+            stderrln("Package $package errored", Color::RED);
+        }
+    }
+
+    private function canUse(string $package)
+    {
+        $result = false;
+        $file = fopen($this->lockFile, 'a+b');
+        flock($file, LOCK_EX);
+        fseek($file, 0);
+        $content = fread($file, filesize($this->lockFile));
+        $locked = explode(PHP_EOL, $content);
+
+        if (!in_array($package, $locked)) {
+            fwrite($file, PHP_EOL . $package);
+            $result = true;
+        }
+
+        flock($file, LOCK_UN);
+        fclose($file);
+
+        return $result;
+    }
+
+    private function fork(): bool
+    {
+        if (function_exists('posix_fork')) {
+            $pid = pcntl_fork();
+
+            if ($pid < 0) {
+                stdoutln("Cannot fork", Color::RED);
+                exit(1);
+            }
+
+            if ($pid === 0) {
+                $this->isParent = false;
+
+                // We are a fork, so we should make the main work
+                return true;
+            }
+
+            // We just created a fork, so we shouldn't do anything
+            return false;
+        }
+
+        // We can't create a fork, so we must do our best ourselves
+        return true;
+    }
+
+    private function waitForks()
+    {
+        if (function_exists('pcntl_wait')) {
+            for ($i = 0; $i < self::THREADS_MAX; $i++) {
+                pcntl_wait($status);
+            }
+        }
+    }
+}

--- a/commands/DependencyVerifyCommand.php
+++ b/commands/DependencyVerifyCommand.php
@@ -138,7 +138,7 @@ class DependencyVerifyCommand
             $pid = pcntl_fork();
 
             if ($pid < 0) {
-                stdoutln("Cannot fork", Color::RED);
+                stderrln("Cannot fork", Color::RED);
                 exit(1);
             }
 

--- a/commands/DependencyVerifyCommand.php
+++ b/commands/DependencyVerifyCommand.php
@@ -14,7 +14,7 @@ class DependencyVerifyCommand
     private $errored = [];
     private $isParent = true;
 
-    public function run()
+    public function run(array $allowed = [])
     {
         $packages = require __DIR__ . '/../packages.php';
 
@@ -37,7 +37,7 @@ class DependencyVerifyCommand
         }
 
         foreach ($packages as $package => $directory) {
-            if ($shouldWork) {
+            if ($shouldWork && ($allowed === [] || in_array($package, $allowed, true))) {
                 if ($this->canUse($package)) {
                     $targetPath = $this->packagesDir . DIRECTORY_SEPARATOR . $directory;
 
@@ -56,7 +56,7 @@ class DependencyVerifyCommand
             $time = round(microtime(true) - $start, 2);
             stdoutln('');
             stdoutln('');
-            stdoutln("Finished in $time sec. You can see the result in $this->logFile", Color::GREEN);
+            stdoutln("Finished in $time sec. You can see error details (if any) in $this->logFile", Color::GREEN);
         }
     }
 
@@ -89,7 +89,7 @@ class DependencyVerifyCommand
         $file = fopen($this->lockFile, 'a+b');
         flock($file, LOCK_EX);
         fseek($file, 0);
-        $content = fread($file, filesize($this->lockFile));
+        $content = @fread($file, filesize($this->lockFile));
         $locked = explode(PHP_EOL, $content);
 
         if (!in_array($package, $locked)) {

--- a/commands/InstallCommand.php
+++ b/commands/InstallCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 /**
  * @author Carsten Brandt <mail@cebe.cc>
  */
@@ -53,18 +55,18 @@ class InstallCommand
             $targetPath = $this->baseDir . DIRECTORY_SEPARATOR . $dir;
             $this->linkPackages($p, $targetPath, $installedPackages);
         }
-        stdoutln('done.', 32);
+        stdoutln('done.', Color::GREEN);
     }
 
     private function install(string $package, string $targetPath): void
     {
         stdout('Installing package  ');
-        stdout($package, 33);
+        stdout($package, Color::YELLOW);
 
         $repo = ($this->useHttp ? 'https://github.com/' : 'git@github.com:') . $package . '.git';
 
         if (file_exists($targetPath)) {
-            stdoutln(' - already installed', 32);
+            stdoutln(' - already installed', Color::GREEN);
 
             return;
         }
@@ -72,7 +74,7 @@ class InstallCommand
 
         passthru('git clone ' . escapeshellarg($repo) . ' ' . escapeshellarg($targetPath));
 
-        stdoutln('done.', 32);
+        stdoutln('done.', Color::GREEN);
     }
 
     private function clearLinks(string $targetPath): void
@@ -88,18 +90,18 @@ class InstallCommand
     {
         if (!is_file("$targetPath/composer.json")) {
             stdout('no composer.json in ');
-            stdout($package, 33);
+            stdout($package, Color::YELLOW);
             stdoutln(', skipping composer install.');
 
             return;
         }
         stdout('composer install in ');
-        stdout($package, 33);
+        stdout($package, Color::YELLOW);
         stdoutln('...');
 
         $command = 'composer install --prefer-dist --no-progress --working-dir ' . escapeshellarg($targetPath) . (ENABLE_COLOR ? ' --ansi' : ' --no-ansi');
         passthru($command);
-        stdoutln('done.', 32);
+        stdoutln('done.', Color::GREEN);
     }
 
     private function linkPackages(string $package, string $targetPath, array $installedPackages): void

--- a/commands/PullCommand.php
+++ b/commands/PullCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 class PullCommand
 {
     private $package;
@@ -35,7 +37,7 @@ class PullCommand
 
     private function pull(string $package, string $targetPath): void
     {
-        stdoutln($package, 32);
+        stdoutln($package, Color::GREEN);
         $command = 'cd ' . escapeshellarg($targetPath) . ' && git pull';
         $output = trim(shell_exec($command));
 

--- a/commands/PushCommand.php
+++ b/commands/PushCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 class PushCommand
 {
     private $package;
@@ -35,7 +37,7 @@ class PushCommand
 
     private function push(string $package, string $targetPath): void
     {
-        stdoutln($package, 32);
+        stdoutln($package, Color::GREEN);
         $command = 'cd ' . escapeshellarg($targetPath) . ' && git push';
         $output = trim(shell_exec($command));
 

--- a/commands/ReplicateCommand.php
+++ b/commands/ReplicateCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 class ReplicateCommand
 {
     private $package;
@@ -50,7 +52,7 @@ class ReplicateCommand
 
     private function replicate(string $package, string $targetPath, string $sourcePath, array $sourceFiles): void
     {
-        stdout("$package ", 32);
+        stdout("$package ", Color::GREEN);
 
         if (!\file_exists($targetPath)) {
             echo stdoutln('❌');

--- a/commands/StatusCommand.php
+++ b/commands/StatusCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 class StatusCommand
 {
     private $package;
@@ -37,7 +39,7 @@ class StatusCommand
     {
         $command = 'cd ' . escapeshellarg($targetPath) . ' && git status -s';
         $output = trim(shell_exec($command));
-        stdoutln($package, empty($output) ? 32 : 33);
+        stdoutln($package, empty($output) ? Color::GREEN : Color::YELLOW);
         if (!empty($output)) {
             echo $output . "\n\n";
         }

--- a/commands/UpdateCommand.php
+++ b/commands/UpdateCommand.php
@@ -2,6 +2,8 @@
 
 namespace yiidev\commands;
 
+use Color;
+
 /**
  * @author Carsten Brandt <mail@cebe.cc>
  */
@@ -53,18 +55,18 @@ class UpdateCommand
             $targetPath = $this->baseDir . DIRECTORY_SEPARATOR . $dir;
             $this->linkPackages($p, $targetPath, $installedPackages);
         }
-        stdoutln('done.', 32);
+        stdoutln('done.', Color::GREEN);
     }
 
     private function install(string $package, string $targetPath): void
     {
         stdout('Ensuring package is installed  ');
-        stdout($package, 33);
+        stdout($package, Color::YELLOW);
 
         $repo = ($this->useHttp ? 'https://github.com/' : 'git@github.com:') . $package . '.git';
 
         if (file_exists($targetPath)) {
-            stdoutln(' - already installed', 32);
+            stdoutln(' - already installed', Color::GREEN);
 
             return;
         }
@@ -72,7 +74,7 @@ class UpdateCommand
 
         passthru('git clone ' . escapeshellarg($repo) . ' ' . escapeshellarg($targetPath));
 
-        stdoutln('done.', 32);
+        stdoutln('done.', Color::GREEN);
     }
 
     private function clearLinks(string $targetPath): void
@@ -88,18 +90,18 @@ class UpdateCommand
     {
         if (!is_file("$targetPath/composer.json")) {
             stdout('no composer.json in ');
-            stdout($package, 33);
+            stdout($package, Color::YELLOW);
             stdoutln(', skipping composer update.');
 
             return;
         }
         stdout('composer update in ');
-        stdout($package, 33);
+        stdout($package, Color::YELLOW);
         stdoutln('...');
 
         $command = 'composer update --prefer-dist --no-progress --working-dir ' . escapeshellarg($targetPath) . (ENABLE_COLOR ? ' --ansi' : ' --no-ansi');
         passthru($command);
-        stdoutln('done.', 32);
+        stdoutln('done.', Color::GREEN);
     }
 
     private function linkPackages(string $package, string $targetPath, array $installedPackages): void

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/yii-dev
+++ b/yii-dev
@@ -13,6 +13,26 @@ define('ENABLE_COLOR', DIRECTORY_SEPARATOR === '\\'
     : function_exists('posix_isatty') && @posix_isatty(STDOUT) && @posix_isatty(STDERR)
 );
 
+class Color {
+    public const DEFAULT = 39;
+    public const BLACK = 30;
+    public const RED = 31;
+    public const GREEN = 32;
+    public const YELLOW = 33;
+    public const BLUE = 34;
+    public const MAGENTA = 35;
+    public const CYAN = 36;
+    public const LIGHT_GRAY = 37;
+    public const DARK_GRAY = 90;
+    public const LIGHT_RED = 91;
+    public const LIGHT_GREEN = 92;
+    public const LIGHT_YELLOW = 93;
+    public const LIGHT_BLUE = 94;
+    public const LIGHT_MAGENTA = 95;
+    public const LIGHT_CYAN = 96;
+    public const WHITE = 97;
+}
+
 /**
  * @param string $text the text to print.
  * @param int|null $color color according to https://en.wikipedia.org/wiki/ANSI_escape_code#3/4_bit
@@ -154,7 +174,14 @@ switch ($command) {
     case 'lint':
 
         // TODO implement
-        stderrln('Not implemented yet!', 31);
+        stderrln('Not implemented yet!', Color::RED);
+
+        break;
+    case 'composer-verify':
+
+        require __DIR__ . '/commands/DependencyVerifyCommand.php';
+        $command = new \yiidev\commands\DependencyVerifyCommand();
+        $command->run();
 
         break;
     default:

--- a/yii-dev
+++ b/yii-dev
@@ -85,37 +85,44 @@ YII
     stderrln('Available Commands:');
     stderrln('');
 
-    stderr('  install', 33);
+    stderr('  install', Color::YELLOW);
     stderrln('             Install all packages listed in packages.php or package specified');
 
-    stderr('  install', 33);
-    stderr(' <package>', 34);
+    stderr('  install', Color::YELLOW);
+    stderr(' <package>', Color::BLUE);
     stderrln('   Install a single package. <package> refers to the array key in packages.php');
 
-    stderr('  update', 33);
+    stderr('  update', Color::YELLOW);
     stderrln('              Update all packages listed in packages.php or package specified');
 
-    stderr('  update', 33);
-    stderr(' <package>', 34);
+    stderr('  update', Color::YELLOW);
+    stderr(' <package>', Color::BLUE);
     stderrln('    Update a single package. <package> refers to the array key in packages.php');
 
-    stderr('  status', 33);
+    stderr('  status', Color::YELLOW);
     stderrln('              Show git status for all packages');
 
-    stderr('  replicate', 33);
+    stderr('  replicate', Color::YELLOW);
     stderrln('           Copy files specified in replicate.php into each package or package specified');
 
-    stderr('  commit', 33);
+    stderr('  commit', Color::YELLOW);
     stderrln('              Add and commit changes into each repository');
 
-    stderr('  push', 33);
+    stderr('  push', Color::YELLOW);
     stderrln('                Push changes into each repository');
 
-    stderr('  pull', 33);
+    stderr('  pull', Color::YELLOW);
     stderrln('                Pull changes for each repository');
 
-    stderr('  lint', 33);
+    stderr('  lint', Color::YELLOW);
     stderrln('                Check packages for common mistakes');
+
+    stderr('  composer-verify', Color::YELLOW);
+    stderrln('     Checks if composer can install dependencies for all packages');
+
+    stderr('  composer-verify', Color::YELLOW);
+    stderr(' <package>[, package]', Color::BLUE);
+    stderrln(' Checks if composer can install dependencies for specified packages');
     stderrln('');
 }
 
@@ -178,10 +185,12 @@ switch ($command) {
 
         break;
     case 'composer-verify':
+        $arguments = $argv;
+        unset($arguments[0], $arguments[1]);
 
         require __DIR__ . '/commands/DependencyVerifyCommand.php';
         $command = new \yiidev\commands\DependencyVerifyCommand();
-        $command->run();
+        $command->run($arguments);
 
         break;
     default:


### PR DESCRIPTION
Added dependency verifier which tries to execute `composer update` for all the packages and then says what's ok and what is not. Command logfile `runtime/composer-verify.log` contains `composer update` log for failed packages.
_In *nix it will work in 5 forks and in windows it will work in one process._

**Needs to be tested on Windows (I haven't an ability to do this).**

Example:
![image](https://user-images.githubusercontent.com/7670669/60595248-49880780-9daf-11e9-9a21-87e7ab640569.png)
