### PR TITLE
Fix #279: Add link to upgrade notes to news text

### DIFF
--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -320,6 +320,6 @@ final class MakeCommand extends PackageCommand
         $upgradeNotesLink
         TEXT;
 
-        $io->info(trim($text)). "\n");
+        $io->info(trim($text) . "\n");
     }
 }

--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -289,7 +289,7 @@ final class MakeCommand extends PackageCommand
 
         $upgradeNotesLink = '';
         $upgradePath = $package->getPath() . '/UPGRADE.md';
-        if (file_exists($upgradePath)) {
+        if (is_file($upgradePath)) {
             $upgradeNotesLink = "\n\nSee [UPGRADE.md](https://github.com/yiisoft/$packageName/blob/$versionToRelease/UPGRADE.md) for upgrade notes.";
         }
 

--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -306,13 +306,20 @@ final class MakeCommand extends PackageCommand
 
         $changes = implode("\n", $changes);
 
+        $upgradeNotesLink = '';
+        $upgradePath = $package->getPath() . '/UPGRADE.md';
+        if (file_exists($upgradePath)) {
+            $upgradeNotesLink = "\n\nSee [UPGRADE.md](https://github.com/yiisoft/$packageName/blob/$versionToRelease/UPGRADE.md) for upgrade notes.";
+        }
+
         $text = <<<TEXT
         [$description](https://github.com/yiisoft/$packageName) version $versionToRelease was released.
         In this version:
 
         $changes
+        $upgradeNotesLink
         TEXT;
 
-        $io->info($text . "\n");
+        $io->info(trim($text)). "\n");
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #279 
