### PR TITLE
Fix release news for multiline changelog items

### DIFF
--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -274,18 +274,10 @@ final class MakeCommand extends PackageCommand
         $io->info("\n---\n");
         $io->info('<fg=green>' . $description . ' ' . $versionToRelease . "</>\n");
 
-        $changes = [];
-
-        foreach ($changelog->getReleaseNotes($versionToRelease) as $note) {
-            $note = trim($note);
-            if ($note === '') {
-                continue;
-            }
-
-            $changes[] = '- ' . preg_replace('~^-.*?:\s+(.*)\s+\(.*\)$~', '$1', $note);
-        }
-
-        $changes = implode("\n", $changes);
+        $changes = implode(
+            "\n",
+            (new ReleaseNews())->getChanges($changelog->getReleaseNotes($versionToRelease))
+        );
 
         $text = <<<TEXT
         [$description](https://github.com/$packageName) version $versionToRelease was released.

--- a/src/App/Command/Release/ReleaseNews.php
+++ b/src/App/Command/Release/ReleaseNews.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\App\Command\Release;
+
+use Yiisoft\YiiDevTool\Infrastructure\Changelog;
+
+final class ReleaseNews
+{
+    /**
+     * @param string[] $releaseNotes
+     *
+     * @return string[]
+     */
+    public function getChanges(array $releaseNotes): array
+    {
+        $changes = [];
+
+        foreach ($releaseNotes as $note) {
+            $note = trim($note);
+            if ($note === '') {
+                continue;
+            }
+
+            $note = preg_replace('~\R\s*~', ' ', $note);
+            $note = preg_replace(
+                '~^- (?:' . implode('|', Changelog::TYPES) . ')(?: #\d+(?:, #\d+)*)?:\s+~',
+                '',
+                $note
+            );
+            $note = preg_replace('~^- \s*~', '', $note);
+            $note = preg_replace('~\s+\(@[^)]*\)$~', '', $note);
+
+            $changes[] = '- ' . $note;
+        }
+
+        return $changes;
+    }
+}

--- a/tests/App/Command/Release/ReleaseNewsTest.php
+++ b/tests/App/Command/Release/ReleaseNewsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\Test\App\Command\Release;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\YiiDevTool\App\Command\Release\ReleaseNews;
+
+final class ReleaseNewsTest extends TestCase
+{
+    public function testGetChangesWithMultilineChangelogItem(): void
+    {
+        $releaseNews = new ReleaseNews();
+
+        $this->assertSame(
+            [
+                '- Minor refactor `RequestBodyParser`: use `str_contains()` function instead of `strpos()` and `::class` instead of `get_class()`',
+                '- Explicitly mark nullable parameters',
+            ],
+            $releaseNews->getChanges(
+                [
+                    "- Enh #47: Minor refactor `RequestBodyParser`: use `str_contains()` function instead of `strpos()` and `::class` instead\n  of `get_class()` (@vjik)",
+                    '- Bug #44: Explicitly mark nullable parameters (@vjik)',
+                ]
+            )
+        );
+    }
+}

--- a/tests/App/Command/Release/ReleaseNewsTest.php
+++ b/tests/App/Command/Release/ReleaseNewsTest.php
@@ -20,7 +20,7 @@ final class ReleaseNewsTest extends TestCase
             ],
             $releaseNews->getChanges(
                 [
-                    "- Enh #47: Minor refactor `RequestBodyParser`: use `str_contains()` function instead of `strpos()` and `::class` instead\n  of `get_class()` (@vjik)",
+                    "- Enh #47: Minor refactor `RequestBodyParser`: use `str_contains()` function instead of `strpos()`\n   and `::class` instead\n  of `get_class()` (@vjik)",
                     '- Bug #44: Explicitly mark nullable parameters (@vjik)',
                 ]
             )


### PR DESCRIPTION
Fixes #328.

## Summary
- Preserve multiline changelog items when generating release news text.
- Add a regression test for multiline changelog entries.

## Tests
- vendor/bin/phpunit