### PR TITLE
Fix #297: Add compare link to release notes

### DIFF
--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -178,7 +178,7 @@ final class MakeCommand extends PackageCommand
             $git->push();
             $git->pushTag((string) $versionToRelease);
 
-            $this->releaseOnGithub($gitHubToken, $package, $versionToRelease);
+            $this->releaseOnGithub($gitHubToken, $package, $currentVersion, $versionToRelease);
 
             $io->done();
 
@@ -223,7 +223,7 @@ final class MakeCommand extends PackageCommand
             ->tags()
             ->all();
         rsort($tags, SORT_NATURAL); // TODO this can not deal with alpha/beta/rc...
-        return new Version(reset($tags));
+        return new Version($tags === [] ? '' : reset($tags));
     }
 
     private function getVersionToRelease(Version $currentVersion): Version
@@ -239,8 +239,12 @@ final class MakeCommand extends PackageCommand
         return $nextVersion;
     }
 
-    private function releaseOnGithub(string $token, Package $package, Version $versionToRelease): void
-    {
+    private function releaseOnGithub(
+        string $token,
+        Package $package,
+        Version $previousVersion,
+        Version $versionToRelease
+    ): void {
         $io = $this->getIO();
         $io->info("Creating release on GitHub for $versionToRelease.\n");
 
@@ -250,10 +254,12 @@ final class MakeCommand extends PackageCommand
         $client->authenticate($token, null, AuthMethod::ACCESS_TOKEN);
         $release = new Releases($client);
 
-        $body = implode("\n", $changelog->getReleaseNotes($versionToRelease));
-
-        $changelogUrl = "https://github.com/{$package->getName()}/blob/$versionToRelease/CHANGELOG.md";
-        $body .= "\n\n[Full changelog]($changelogUrl)";
+        $body = (new ReleaseDescription())->getBody(
+            $package->getName(),
+            $previousVersion,
+            $versionToRelease,
+            $changelog->getReleaseNotes($versionToRelease)
+        );
 
         $release->create($package->getVendor(), $package->getId(), [
             'name' => sprintf('Version %s', $versionToRelease),

--- a/src/App/Command/Release/ReleaseDescription.php
+++ b/src/App/Command/Release/ReleaseDescription.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\App\Command\Release;
+
+use Yiisoft\YiiDevTool\Infrastructure\Version;
+
+final class ReleaseDescription
+{
+    /**
+     * @param string[] $releaseNotes
+     */
+    public function getBody(
+        string $packageName,
+        Version $previousVersion,
+        Version $versionToRelease,
+        array $releaseNotes
+    ): string {
+        $body = implode("\n", $releaseNotes);
+
+        if ($previousVersion->asString() === '') {
+            return $body;
+        }
+
+        $changelogUrl = "https://github.com/$packageName/compare/$previousVersion...$versionToRelease";
+
+        return $body . "\n\n[Full changelog]($changelogUrl)";
+    }
+}

--- a/tests/App/Command/Release/ReleaseDescriptionTest.php
+++ b/tests/App/Command/Release/ReleaseDescriptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\Test\App\Command\Release;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\YiiDevTool\App\Command\Release\ReleaseDescription;
+use Yiisoft\YiiDevTool\Infrastructure\Version;
+
+final class ReleaseDescriptionTest extends TestCase
+{
+    public function testGetBodyAddsFullChangelogCompareLink(): void
+    {
+        $description = new ReleaseDescription();
+
+        $expectedBody = <<<BODY
+        - Bug #1: Fixed issue (@samdark)
+
+        [Full changelog](https://github.com/yiisoft/html/compare/3.10.0...3.11.0)
+        BODY;
+
+        $this->assertSame(
+            $expectedBody,
+            $description->getBody(
+                'yiisoft/html',
+                new Version('3.10.0'),
+                new Version('3.11.0'),
+                ['- Bug #1: Fixed issue (@samdark)']
+            )
+        );
+    }
+
+    public function testGetBodyDoesNotAddFullChangelogLinkWithoutPreviousVersion(): void
+    {
+        $description = new ReleaseDescription();
+
+        $this->assertSame(
+            '- Initial release.',
+            $description->getBody(
+                'yiisoft/html',
+                new Version(''),
+                new Version('1.0.0'),
+                ['- Initial release.']
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #297.

Summary:
- Build GitHub release descriptions with a Full changelog link to the GitHub compare view between the previous tag and the new release tag.
- Omit the compare link when there is no previous version.
- Add unit tests for release description generation.

Tests:
- vendor/bin/phpunit
- vendor/bin/phpstan analyse src/App/Command/Release tests/App/Command/Release --no-progress
- vendor/bin/phpcs --standard=PSR12 src/App/Command/Release/MakeCommand.php src/App/Command/Release/ReleaseDescription.php tests/App/Command/Release/ReleaseDescriptionTest.php (reports existing long-line warnings in MakeCommand.php)