### PR TITLE
Fix #256: Fix release:what dependency package list

### DIFF
--- a/src/App/Command/Release/WhatCommand.php
+++ b/src/App/Command/Release/WhatCommand.php
@@ -64,10 +64,12 @@ final class WhatCommand extends Command
                 exit(1);
             }
 
+            $packagesRootDir = $this->getApplication()->getConfig('packagesRootDir') ?? $this->getAppRootDir() . 'dev';
+
             $this->packageList = new PackageList(
                 $ownerPackages,
                 $this->getAppRootDir() . 'packages.php',
-                $this->getAppRootDir() . 'dev',
+                $packagesRootDir,
             );
         } catch (InvalidArgumentException $e) {
             $io->error([
@@ -93,22 +95,28 @@ final class WhatCommand extends Command
 
         // Get packages without release.
         foreach ($installedPackages as $installedPackage) {
-            if ($this->hasRelease($installedPackage)) {
-                $io->info("Skip {$installedPackage->getName()}. Already released.");
-                // Skip released packages.
-                continue;
-            }
-
             if (!$installedPackage->composerConfigFileExists()) {
                 $io->info("Skip {$installedPackage->getName()}. No composer.json.");
                 // Skip packages without composer.json.
                 continue;
             }
 
+            if (!$installedPackage->isGitRepositoryCloned()) {
+                $io->info("Skip {$installedPackage->getName()}. No git working copy.");
+                // Skip packages without a git working copy.
+                continue;
+            }
+
+            if ($this->hasRelease($installedPackage)) {
+                $io->info("Skip {$installedPackage->getName()}. Already released.");
+                // Skip released packages.
+                continue;
+            }
+
             $packagesWithoutRelease[$installedPackage->getName()] = [
                 'dependencies' => 0,
                 'dependents' => 0,
-                'deps' => [],
+                'dependencyPackages' => [],
             ];
         }
 
@@ -126,9 +134,8 @@ final class WhatCommand extends Command
                 }
 
                 $packagesWithoutRelease[$dependencyName]['dependents']++;
-                $packagesWithoutRelease[$dependencyName]['deps'][] = $this->removeVendorName($installedPackage->getName());
                 $packagesWithoutRelease[$installedPackage->getName()]['dependencies']++;
-                $packagesWithoutRelease[$installedPackage->getName()]['deps'][] = $this->removeVendorName($dependencyName);
+                $packagesWithoutRelease[$installedPackage->getName()]['dependencyPackages'][] = $this->removeVendorName($dependencyName);
             }
         }
 
@@ -148,20 +155,20 @@ final class WhatCommand extends Command
                     new TableCell($packageName, ['style' => $errorStyle]),
                     $stats['dependencies'],
                     $stats['dependents'],
-                    $this->concatDependencies($stats['deps']),
+                    $this->concatDependencies($stats['dependencyPackages']),
                 ];
             } else {
                 $packagesToRelease[] = [
                     new TableCell($packageName, ['style' => $successStyle]),
                     $stats['dependencies'],
                     $stats['dependents'],
-                    $this->concatDependencies($stats['deps']),
+                    $this->concatDependencies($stats['dependencyPackages']),
                 ];
             }
         }
 
         $tableIO = new Table($output);
-        $tableIO->setHeaders(['Package', 'Out deps', 'In deps', 'Packages']);
+        $tableIO->setHeaders(['Package', 'Out deps', 'In deps', 'Out packages']);
         $tableIO->setColumnMaxWidth(3, 120);
 
         if (count($packagesToRelease) > 0) {
@@ -191,6 +198,7 @@ final class WhatCommand extends Command
                 <<<TEXT
         <success>Out deps</success> – count unreleased packages from which the package depends
         <success>In deps</success> – count unreleased packages which depends on the package
+        <success>Out packages</success> – unreleased packages from which the package depends
         TEXT
             );
 

--- a/tests/App/Command/Release/WhatCommandTest.php
+++ b/tests/App/Command/Release/WhatCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\Test\App\Command\Release;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Yiisoft\YiiDevTool\App\YiiDevToolApplication;
+
+final class WhatCommandTest extends TestCase
+{
+    private string $rootDir;
+    private string $packagesRootDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootDir = sys_get_temp_dir() . '/yii-dev-tool-what-command-' . bin2hex(random_bytes(8));
+        $this->packagesRootDir = sys_get_temp_dir() . '/yii-dev-tool-what-command-packages-' . bin2hex(random_bytes(8));
+
+        (new Filesystem())->mkdir([$this->rootDir, $this->packagesRootDir]);
+
+        file_put_contents($this->rootDir . '/owner-packages.php', "<?php\n\nreturn 'yiisoft';\n");
+        file_put_contents(
+            $this->rootDir . '/packages.php',
+            "<?php\n\nreturn [\n    'demo' => true,\n    'input-http' => true,\n    'request-model' => true,\n    'validator' => true,\n];\n"
+        );
+
+        (new Filesystem())->mkdir($this->packagesRootDir . '/demo');
+
+        $this->createPackage('input-http', ['yiisoft/request-model' => '^1.0']);
+        $this->createPackage('request-model', ['yiisoft/validator' => '^1.0']);
+        $this->createPackage('validator');
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove([$this->rootDir, $this->packagesRootDir]);
+
+        parent::tearDown();
+    }
+
+    public function testListsOnlyOutgoingPackages(): void
+    {
+        $application = (new YiiDevToolApplication(['packagesRootDir' => $this->packagesRootDir]))
+            ->setRootDir($this->rootDir);
+        $command = $application->find('release:what');
+
+        $commandTester = new CommandTester($command);
+        $this->assertSame(0, $commandTester->execute([]));
+
+        $output = $commandTester->getDisplay();
+
+        $this->assertStringContainsString('Out packages', $output);
+        $this->assertMatchesRegularExpression(
+            '/\| yiisoft\/request-model\s+\| 1\s+\| 1\s+\| validator\s+\|/',
+            $output
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/\| yiisoft\/request-model\s+\| 1\s+\| 1\s+\|[^\n]*input-http/',
+            $output
+        );
+    }
+
+    private function createPackage(string $name, array $require = []): void
+    {
+        $packageDir = $this->packagesRootDir . '/' . $name;
+        (new Filesystem())->mkdir($packageDir);
+
+        $composer = [
+            'name' => 'yiisoft/' . $name,
+            'require' => $require,
+        ];
+
+        file_put_contents(
+            $packageDir . '/composer.json',
+            json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+        );
+
+        (new Process(['git', 'init', '--quiet'], $packageDir))->mustRun();
+    }
+}


### PR DESCRIPTION
Fixes #256.

## Summary
- honor configured `packagesRootDir` in `release:what` so packages outside the tool-root `dev` directory are detected
- skip package directories that have no `composer.json` or no git working copy instead of aborting the report
- track outgoing dependency package names separately from incoming dependent counts
- rename the package-name column to `Out packages` to match the values shown
- add a regression test for the request-model / validator case using a custom packages root and an incomplete package directory

## Tests
- `vendor/bin/phpunit tests/App/Command/Release/WhatCommandTest.php`
- `vendor/bin/phpunit`
- `php yii-dev release:what`