### PR TITLE
Fix #279: Link upgrade notes for major releases

### DIFF
--- a/src/App/Command/Release/MakeCommand.php
+++ b/src/App/Command/Release/MakeCommand.php
@@ -20,6 +20,7 @@ use Yiisoft\YiiDevTool\Infrastructure\Composer\Config\ComposerConfig;
 use Yiisoft\YiiDevTool\Infrastructure\Version;
 
 use function in_array;
+use function is_file;
 use function sprintf;
 
 final class MakeCommand extends PackageCommand
@@ -258,7 +259,8 @@ final class MakeCommand extends PackageCommand
             $package->getName(),
             $previousVersion,
             $versionToRelease,
-            $changelog->getReleaseNotes($versionToRelease)
+            $changelog->getReleaseNotes($versionToRelease),
+            is_file($package->getPath() . '/UPGRADE.md')
         );
 
         $release->create($package->getVendor(), $package->getId(), [

--- a/src/App/Command/Release/ReleaseDescription.php
+++ b/src/App/Command/Release/ReleaseDescription.php
@@ -6,6 +6,8 @@ namespace Yiisoft\YiiDevTool\App\Command\Release;
 
 use Yiisoft\YiiDevTool\Infrastructure\Version;
 
+use function preg_match;
+
 final class ReleaseDescription
 {
     /**
@@ -15,7 +17,8 @@ final class ReleaseDescription
         string $packageName,
         Version $previousVersion,
         Version $versionToRelease,
-        array $releaseNotes
+        array $releaseNotes,
+        bool $hasUpgradeNotes = false
     ): string {
         $body = implode("\n", $releaseNotes);
 
@@ -24,7 +27,18 @@ final class ReleaseDescription
         }
 
         $changelogUrl = "https://github.com/$packageName/compare/$previousVersion...$versionToRelease";
+        $body .= "\n\n[Full changelog]($changelogUrl)";
 
-        return $body . "\n\n[Full changelog]($changelogUrl)";
+        if ($hasUpgradeNotes && $this->isMajorRelease($versionToRelease)) {
+            $upgradeNotesUrl = "https://github.com/$packageName/blob/$versionToRelease/UPGRADE.md";
+            $body .= "\n\nSee [UPGRADE.md]($upgradeNotesUrl) for upgrade notes.";
+        }
+
+        return $body;
+    }
+
+    private function isMajorRelease(Version $version): bool
+    {
+        return preg_match('/^\d+\.0\.0$/', $version->asString()) === 1;
     }
 }

--- a/tests/App/Command/Release/ReleaseDescriptionTest.php
+++ b/tests/App/Command/Release/ReleaseDescriptionTest.php
@@ -45,4 +45,71 @@ final class ReleaseDescriptionTest extends TestCase
             )
         );
     }
+
+    public function testGetBodyAddsUpgradeNotesLinkForMajorReleaseWhenUpgradeNotesExist(): void
+    {
+        $description = new ReleaseDescription();
+
+        $expectedBody = <<<BODY
+        - Enh #1: Removed deprecated API (@samdark)
+
+        [Full changelog](https://github.com/yiisoft/html/compare/3.10.0...4.0.0)
+
+        See [UPGRADE.md](https://github.com/yiisoft/html/blob/4.0.0/UPGRADE.md) for upgrade notes.
+        BODY;
+
+        $this->assertSame(
+            $expectedBody,
+            $description->getBody(
+                'yiisoft/html',
+                new Version('3.10.0'),
+                new Version('4.0.0'),
+                ['- Enh #1: Removed deprecated API (@samdark)'],
+                true
+            )
+        );
+    }
+
+    public function testGetBodyDoesNotAddUpgradeNotesLinkForMinorRelease(): void
+    {
+        $description = new ReleaseDescription();
+
+        $expectedBody = <<<BODY
+        - Enh #1: Added API (@samdark)
+
+        [Full changelog](https://github.com/yiisoft/html/compare/3.10.0...3.11.0)
+        BODY;
+
+        $this->assertSame(
+            $expectedBody,
+            $description->getBody(
+                'yiisoft/html',
+                new Version('3.10.0'),
+                new Version('3.11.0'),
+                ['- Enh #1: Added API (@samdark)'],
+                true
+            )
+        );
+    }
+
+    public function testGetBodyDoesNotAddUpgradeNotesLinkWhenUpgradeNotesDoNotExist(): void
+    {
+        $description = new ReleaseDescription();
+
+        $expectedBody = <<<BODY
+        - Enh #1: Removed deprecated API (@samdark)
+
+        [Full changelog](https://github.com/yiisoft/html/compare/3.10.0...4.0.0)
+        BODY;
+
+        $this->assertSame(
+            $expectedBody,
+            $description->getBody(
+                'yiisoft/html',
+                new Version('3.10.0'),
+                new Version('4.0.0'),
+                ['- Enh #1: Removed deprecated API (@samdark)']
+            )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add an optional upgrade-notes link to GitHub release descriptions
- show it only for major releases when UPGRADE.md exists
- cover major, minor, and missing-notes cases in ReleaseDescription tests

## Tests
- vendor/bin/phpunit
- git diff --check

Fixes #279