### PR TITLE
Fix #164: Stream command output

### DIFF
--- a/src/App/Command/ExecCommand.php
+++ b/src/App/Command/ExecCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Process\Process;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
 #[AsCommand(
@@ -66,17 +67,7 @@ final class ExecCommand extends PackageCommand
              * We want to receive the output of the program in real time,
              * so we pass a callback that will read the data as it comes in.
              */
-            ->run(function ($type, $data) use ($io) {
-                /**
-                 * We do not split data into output streams by data type,
-                 * because many programs write non-error messages to the error stream.
-                 *
-                 * We write everything to one regular output stream.
-                 */
-                $io
-                    ->important()
-                    ->write($data);
-            });
+            ->run(ProcessOutput::callback($io));
 
         /**
          * End each program block with a new line so that

--- a/src/App/Command/Git/CheckoutCommand.php
+++ b/src/App/Command/Git/CheckoutCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
 #[AsCommand(
@@ -48,11 +49,12 @@ final class CheckoutCommand extends PackageCommand
             ->getBranches()
             ->all();
         $branchExists = in_array($this->branch, $branches, true);
+        $callback = ProcessOutput::callback($io);
 
         if ($branchExists) {
-            $gitWorkingCopy->checkout($this->branch);
+            $gitWorkingCopy->runWithOutput('checkout', [$this->branch], $callback);
         } else {
-            $gitWorkingCopy->checkoutNewBranch($this->branch);
+            $gitWorkingCopy->runWithOutput('checkout', [['b' => true], $this->branch], $callback);
         }
 
         $io->done();

--- a/src/App/Command/Git/CommitCommand.php
+++ b/src/App/Command/Git/CommitCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Process\Process;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
 #[AsCommand(
@@ -60,19 +61,13 @@ final class CommitCommand extends PackageCommand
         }
 
         $process = new Process(['git', 'commit', '-m', $this->message], $package->getPath());
-        $process->run();
+        ProcessOutput::run($process, $io);
 
         if ($process->isSuccessful()) {
-            $io
-                ->important()
-                ->info($process->getOutput() . $process->getErrorOutput());
             $io->done();
         } else {
             $output = $process->getErrorOutput();
 
-            $io
-                ->important()
-                ->info($output);
             $io->error([
                 "An error occurred during committing package <package>{$package->getId()}</package> repository.",
                 'Package committing aborted.',

--- a/src/App/Command/Git/PullCommand.php
+++ b/src/App/Command/Git/PullCommand.php
@@ -7,6 +7,7 @@ namespace Yiisoft\YiiDevTool\App\Command\Git;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Process;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
 #[AsCommand(
@@ -33,23 +34,14 @@ final class PullCommand extends PackageCommand
         $io->preparePackageHeader($package, 'Pulling package {package}');
 
         $process = new Process(['git', 'pull'], $package->getPath());
-        $process
-            ->setTimeout(null)
-            ->run();
+        $process->setTimeout(null);
+        ProcessOutput::run($process, $io);
 
         if ($process->isSuccessful()) {
-            $output = $process->getOutput() . $process->getErrorOutput();
-
-            $io
-                ->important(trim($output) !== 'Already up to date.')
-                ->info($output);
             $io->done();
         } else {
             $output = $process->getErrorOutput();
 
-            $io
-                ->important()
-                ->info($output);
             $io->error([
                 "An error occurred during pulling package <package>{$package->getId()}</package> repository.",
                 'Package pull aborted.',

--- a/src/App/Command/Git/PushCommand.php
+++ b/src/App/Command/Git/PushCommand.php
@@ -6,6 +6,7 @@ namespace Yiisoft\YiiDevTool\App\Command\Git;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Git\GitException;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
@@ -38,11 +39,12 @@ final class PushCommand extends PackageCommand
             $currentBranch = $gitWorkingCopy
                 ->getBranches()
                 ->head();
+            $callback = ProcessOutput::callback($io);
 
             if ($currentBranch === 'master') {
-                $gitWorkingCopy->push();
+                $gitWorkingCopy->runWithOutput('push', [], $callback);
             } else {
-                $gitWorkingCopy->push('origin', $currentBranch);
+                $gitWorkingCopy->runWithOutput('push', ['origin', $currentBranch], $callback);
             }
 
             $io->done();

--- a/src/App/Command/Git/RequestPullCommand.php
+++ b/src/App/Command/Git/RequestPullCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\Process;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
 #[AsCommand(
@@ -71,12 +72,9 @@ final class RequestPullCommand extends PackageCommand
         }
 
         $process = new Process($processParameters, $package->getPath());
-        $process->run();
+        ProcessOutput::run($process, $io);
 
         if ($process->isSuccessful()) {
-            $io
-                ->important()
-                ->info($process->getOutput() . $process->getErrorOutput());
             $io->done();
 
             return;
@@ -93,9 +91,6 @@ final class RequestPullCommand extends PackageCommand
 
         $output = $process->getErrorOutput();
 
-        $io
-            ->important()
-            ->info($output);
         $io->error([
             "An error occurred during creating PR for package <package>{$package->getId()}</package> repository.",
             'Creating PR aborted.',

--- a/src/App/Command/LintCommand.php
+++ b/src/App/Command/LintCommand.php
@@ -6,6 +6,7 @@ namespace Yiisoft\YiiDevTool\App\Command;
 
 use Symfony\Component\Process\Process;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
 final class LintCommand extends PackageCommand
@@ -42,13 +43,9 @@ final class LintCommand extends PackageCommand
             '--ignore=*/vendor/*,*/docs/*',
         ], $this->getAppRootDir());
 
-        $process->run();
+        ProcessOutput::run($process, $io);
 
-        if ($process->getExitCode() > 0) {
-            $io
-                ->important()
-                ->info($process->getOutput() . $process->getErrorOutput());
-        } else {
+        if ($process->getExitCode() === 0) {
             $io->success('✔ No problems found.');
         }
     }

--- a/src/App/Command/TestCommand.php
+++ b/src/App/Command/TestCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\Process;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 
@@ -44,7 +45,7 @@ final class TestCommand extends PackageCommand
             'test',
         ], $package->getPath());
         $process->setTimeout(20);
-        $process->run();
+        ProcessOutput::run($process, $io);
 
         if (!$process->isSuccessful() && $this->isComposerTestNotImplemented($process)) {
             $command = [
@@ -60,7 +61,7 @@ final class TestCommand extends PackageCommand
 
             $process = new Process($command, $package->getPath());
             $process->setTimeout(20);
-            $process->run();
+            ProcessOutput::run($process, $io);
         }
 
         if ($process->getExitCode() === 0) {
@@ -77,9 +78,6 @@ final class TestCommand extends PackageCommand
 
         $output = $process->getErrorOutput();
         $this->registerPackageError($package, $output, 'testing package');
-        $io
-            ->important()
-            ->info($process->getOutput() . $output);
     }
 
     private function isComposerTestNotImplemented(Process $process): bool

--- a/src/App/Command/UpdateCommand.php
+++ b/src/App/Command/UpdateCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\Process;
 use Yiisoft\YiiDevTool\App\Component\Console\OutputManager;
 use Yiisoft\YiiDevTool\App\Component\Console\PackageCommand;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 use Yiisoft\YiiDevTool\App\PackageService;
 
@@ -111,18 +112,14 @@ final class UpdateCommand extends PackageCommand
         $process = new Process(['git', 'pull']);
         $process->setWorkingDirectory($package->getPath());
 
-        $process
-            ->setTimeout(null)
-            ->run();
+        $process->setTimeout(null);
+        ProcessOutput::run($process, $io);
+
         if ($process->isSuccessful()) {
-            $io->info($process->getOutput() . $process->getErrorOutput());
             $io->done();
         } else {
             $output = $process->getErrorOutput();
 
-            $io
-                ->important()
-                ->info($output);
             $io->error([
                 'An error occurred during running `git pull`.',
             ]);

--- a/src/App/Component/Console/ProcessOutput.php
+++ b/src/App/Component/Console/ProcessOutput.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\App\Component\Console;
+
+use Closure;
+use Symfony\Component\Process\Process;
+
+final class ProcessOutput
+{
+    public static function callback(OutputManager $io): Closure
+    {
+        return static function (string $type, string $data) use ($io): void {
+            $io
+                ->important()
+                ->write($data);
+        };
+    }
+
+    public static function run(Process $process, OutputManager $io): int
+    {
+        return $process->run(self::callback($io));
+    }
+}

--- a/src/App/Component/Git/GitWorkingCopy.php
+++ b/src/App/Component/Git/GitWorkingCopy.php
@@ -97,12 +97,28 @@ final class GitWorkingCopy
      */
     public function run(string $command, array $argsOrOptions = []): string
     {
+        return $this->runCommand($command, $argsOrOptions);
+    }
+
+    /**
+     * @param mixed[] $argsOrOptions
+     */
+    public function runWithOutput(string $command, array $argsOrOptions, callable $callback): string
+    {
+        return $this->runCommand($command, $argsOrOptions, $callback);
+    }
+
+    /**
+     * @param mixed[] $argsOrOptions
+     */
+    private function runCommand(string $command, array $argsOrOptions = [], ?callable $callback = null): string
+    {
         $process = new Process(
             array_merge([$this->gitBinary, $command], $this->buildArguments($argsOrOptions)),
             $this->directory
         );
         $process->setTimeout(null);
-        $process->run();
+        $process->run($callback);
 
         if (!$process->isSuccessful()) {
             $message = trim($process->getErrorOutput() . $process->getOutput());

--- a/src/App/PackageService.php
+++ b/src/App/PackageService.php
@@ -77,9 +77,6 @@ final class PackageService
         }
 
         $output = $process->getErrorOutput();
-        $io
-            ->important()
-            ->info($output);
 
         $io->error([
             "An error occurred during cloning package <package>{$package->getName()}</package> repository.",

--- a/src/App/PackageService.php
+++ b/src/App/PackageService.php
@@ -8,6 +8,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 use Yiisoft\Files\FileHelper;
 use Yiisoft\YiiDevTool\App\Component\Console\OutputManager;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
 use Yiisoft\YiiDevTool\App\Component\Package\Package;
 use Yiisoft\YiiDevTool\App\Component\Package\PackageErrorList;
 use Yiisoft\YiiDevTool\App\Component\Package\PackageList;
@@ -66,12 +67,11 @@ final class PackageService
         $io->info("Repository url: <file>{$package->getConfiguredRepositoryUrl()}</file>");
 
         $process = new Process(['git', 'clone', $package->getConfiguredRepositoryUrl(), $package->getPath()]);
-        $process
-            ->setTimeout(null)
-            ->run();
+        $process->setTimeout(null);
+
+        ProcessOutput::run($process, $io);
 
         if ($process->isSuccessful()) {
-            $io->info($process->getOutput() . $process->getErrorOutput());
             $io->done();
             return;
         }
@@ -192,19 +192,15 @@ final class PackageService
 
         $process = new Process($params);
 
-        $process
-            ->setTimeout(null)
-            ->run();
+        $process->setTimeout(null);
+
+        ProcessOutput::run($process, $io);
 
         if ($process->isSuccessful()) {
-            $io->info($process->getOutput() . $process->getErrorOutput());
             $io->done();
         } else {
             $output = $process->getErrorOutput();
 
-            $io
-                ->important()
-                ->info($output);
             $io->error([
                 "An error occurred during running `composer $command`.",
                 "Package $command aborted.",

--- a/tests/App/Component/Console/ProcessOutputTest.php
+++ b/tests/App/Component/Console/ProcessOutputTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\YiiDevTool\Test\App\Component\Console;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Process\Process;
+use Yiisoft\YiiDevTool\App\Component\Console\OutputManager;
+use Yiisoft\YiiDevTool\App\Component\Console\ProcessOutput;
+use Yiisoft\YiiDevTool\App\Component\Console\YiiDevToolStyle;
+
+final class ProcessOutputTest extends TestCase
+{
+    public function testRunStreamsOutputBeforeProcessFinishes(): void
+    {
+        $sentinel = tempnam(sys_get_temp_dir(), 'yii-dev-tool-process-output-');
+        unlink($sentinel);
+
+        $output = new class ($sentinel) extends BufferedOutput {
+            public bool $receivedOutputBeforeProcessFinished = false;
+
+            public function __construct(private string $sentinel)
+            {
+                parent::__construct();
+            }
+
+            protected function doWrite(string $message, bool $newline): void
+            {
+                if (str_contains($message, 'started') && !file_exists($this->sentinel)) {
+                    $this->receivedOutputBeforeProcessFinished = true;
+                }
+
+                parent::doWrite($message, $newline);
+            }
+        };
+
+        $process = new Process([
+            PHP_BINARY,
+            '-r',
+            'echo "started\n"; flush(); usleep(200000); touch($argv[1]); echo "finished\n";',
+            $sentinel,
+        ]);
+
+        ProcessOutput::run(
+            $process,
+            new OutputManager(new YiiDevToolStyle(new ArrayInput([]), $output))
+        );
+
+        try {
+            $this->assertTrue($process->isSuccessful());
+            $this->assertTrue($output->receivedOutputBeforeProcessFinished);
+            $this->assertStringContainsString('started', $output->fetch());
+        } finally {
+            if (file_exists($sentinel)) {
+                unlink($sentinel);
+            }
+        }
+    }
+}

--- a/tests/App/Component/Console/ProcessOutputTest.php
+++ b/tests/App/Component/Console/ProcessOutputTest.php
@@ -17,7 +17,11 @@ final class ProcessOutputTest extends TestCase
     public function testRunStreamsOutputBeforeProcessFinishes(): void
     {
         $sentinel = tempnam(sys_get_temp_dir(), 'yii-dev-tool-process-output-');
-        unlink($sentinel);
+        self::assertIsString($sentinel);
+
+        if (file_exists($sentinel)) {
+            unlink($sentinel);
+        }
 
         $output = new class ($sentinel) extends BufferedOutput {
             public bool $receivedOutputBeforeProcessFinished = false;


### PR DESCRIPTION
## Summary
- add a shared ProcessOutput helper for streaming Symfony Process output through the existing console output manager
- stream long-running package commands instead of printing buffered output after completion
- add a regression test proving process output is received before the child process finishes

## Tests
- vendor/bin/phpunit
- vendor/bin/phpcs src/App/Component/Console/ProcessOutput.php tests/App/Component/Console/ProcessOutputTest.php src/App/Component/Git/GitWorkingCopy.php src/App/Command/ExecCommand.php src/App/Command/Git/CheckoutCommand.php src/App/Command/Git/PushCommand.php src/App/Command/Git/CommitCommand.php src/App/Command/Git/PullCommand.php src/App/Command/Git/RequestPullCommand.php src/App/Command/LintCommand.php src/App/Command/TestCommand.php src/App/Command/UpdateCommand.php src/App/PackageService.php --standard=PSR12

Fixes #164